### PR TITLE
Add script to report missing tags in component repos

### DIFF
--- a/util/checktags.py
+++ b/util/checktags.py
@@ -1,0 +1,99 @@
+from github import Github
+import sys
+import semantic_version
+
+if len(sys.argv) <> 3:
+    print "Please specify both username and github password."
+    print "Usage: checktags.py <username> <password>"
+    sys.exit(-1)
+    
+g = Github(sys.argv[1], sys.argv[2])
+
+org = g.get_organization("jbosstools")
+
+#repos not following jbt tagging cycle
+nondevrepos = [
+    "jbosstools-gwt",
+    "jbosstools-deltacloud",
+    "jbosstools-fuse-extras",
+    "jbosstools-devdoc",
+    "jbosstools-locus",
+    "jbosstools-runtime-soa",
+    "jbosstools-maven-plugins",
+    "jbosstools-jbpm",
+    "jbosstools-esb",
+    "jbosstools-documentation",
+    "jbosstools-full-svn-mirror",
+    "jbosstools-website",
+    "m2e-apt",
+    "m2e-wro4j",
+    "m2e-jdt-compiler",
+    "m2e-wtp-tests",
+    "jbosstools-integration-tests",
+     "jbosstools-integration-stack",
+    "jboss-wfk-quickstarts",
+    "jbosstools-playground",
+    "contacts-mobile-basic-cordova",
+    "m2e-polyglot-poc",
+    "jbosstools-bpel",
+    "jbosstools-integration-stack-tests",
+    "jbosstools-xulrunner",
+    "jbosstools-install-rinder",
+    "jbosstools-target-platforms",
+    "jbosstools-central-webpage", ## remove when part of release?
+    "incubator-ripple", ## this should be tagged somehow, but how ?
+    "jbosstools-versionwatch",
+    "jbosstools-archetypes",
+    "jbosstools-install-grinder"
+    ]
+
+since = {
+    "jbosstools-base" : "",
+    "jbosstools-birt" : "jbosstools-4",
+    "jbosstools-build" : "jbosstools-4",
+    "jbosstools-build-ci" : "jbosstools-4",
+    "jbosstools-build-sites" : "jbosstools-4",
+    "jbosstools-central" : "jbosstools-4",
+    "jbosstools-download.jboss.org" : "jbosstools-4",
+    "jbosstools-forge" : "jbosstools-4.1",
+    "jbosstools-javaee" : "",
+    "jbosstools-jst" : "",
+    "jbosstools-openshift" : "jbosstools-4.1",
+    "jbosstools-portlet" : "jbosstools-4",
+    "jbosstools-server" : "",
+    "jbosstools-vpe" : "",
+    "jbosstools-webservices" : "jbosstools-4",
+    "jbosstools-freemarker" : "",
+    "jbosstools-hibernate" : "",
+    "jbosstools-aerogear" : "jbosstools-4.1.0.Alpha2",
+    "jbosstools-discovery" : "jbosstools-4",
+    "jbosstools-livereload" : "jbosstools-4.2",
+    "jbosstools-arquillian" : "jbosstools-4.2",
+    "jbosstools-browsersim" : "jbosstools-4.2.0.Beta1"
+}
+    
+therepo = org.get_repo("jbosstools-base")
+thetags = []
+
+for tag in therepo.get_tags():
+    if tag.name.startswith("jbosstools"):
+        thetags.append(tag.name)
+
+thetags.sort()
+
+
+print "Checking each repo for diff to base repo"
+
+for repo in org.get_repos():
+    if repo.name not in nondevrepos:
+        tags = repo.get_tags()
+        rawtags = []
+        for tag in tags:
+            rawtags.append(tag.name)
+
+        sincetags = [e for e in thetags if e > since[repo.name]]
+        diff = set(sincetags) - set(rawtags)
+        if diff:
+            print "\n" + repo.name + " missing " + str(len(diff)) + " tags: \n  " + ",\n  ".join(sorted(diff))
+        
+ 

--- a/util/readme.adoc
+++ b/util/readme.adoc
@@ -1,0 +1,98 @@
+Scripts for JBoss Tools Build
+=============================
+
+This folder contains various scripts used to validate and check the
+repositories and the build setup for JBoss Tools.
+
+|===
+|Name | Description | Used when
+
+|link:bumpParentPomVersion.sh[]
+|Bump version in list of pom.xml files. 
+|Not recommended for general use. Better to use `mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=<version>`
+
+|link:checkIfBranchesExist.sh[]
+|
+|
+
+|link:checkPOMvsManifest.sh[]
+|
+|
+
+|link:checktags.py[]
+|Checks via GitHub if all tags are present for
+repositories and print out report of repos with missing tags.
+|After builds are done to check all tags are recorded.
+
+|link:cleanup[]
+|Directory with cleanup scripts
+|
+
+|link:generateCompositeStagingSiteMetadata.sh[]
+|
+|
+
+|link:genpom.scala[]
+|Initial code for generating tycho pom for old JBoss Tools projects
+|Deprecated/Not used
+
+|link:genpom.xml[]
+|
+|
+
+|link:getArch.sh[]
+|
+|
+
+|link:getLatestArtifactFromNexus.sh[]
+|
+|
+
+|link:getProjectRootPomParents.sh[]
+|
+|
+
+|link:getProjectSHAs.sh[]
+|
+|
+
+|link:installAndDisplayCompositeSiteContent.sh[]
+|
+|
+
+|link:installFromCentral.sh[]
+|
+|
+
+|link:installFromTarget.sh[]
+|
+|
+
+|link:purgeRemoteFiles.sh[]
+|
+|
+
+|link:purgeRemoteFolders.sh[]
+|
+|
+
+|link:runstack.sh[]
+|
+|
+
+|link:runtests.sh[]
+|
+|
+
+|link:validateCompositeSiteChildrenExist.sh[]
+|
+|
+
+|link:verifyTarget.sh[]
+|
+|
+
+|===
+
+
+


### PR DESCRIPTION
Script has a list of identified repositories and a 'since' table
for each component repo and then simply report the difference
of what tags are missing.

Also add a readme.adoc to give overview over the list of scripts.

Note: could not deduce any consistent naming convention for the scripts 
in here so I used the original one of lowercase.