### PR TITLE
JBIDE-20152 scripts for tagging via buildinfo

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -57,6 +57,14 @@ toc::[]
 |Verifies a target platform is valid, including generation of p2diff
 |Used to verify a target platform changes before submitting a PR
 
+|link:util/tagrepos.sh[tagrepos.py]
+|Tag repos via github API based on a comma separated input list of repos, sha1's and tagname
+|Used to tag all repositories in one batch. Requires push access to all related repositories.
+
+|link:util/buildinfo2tags.py[buildinfo2tags.py]
+|Convert `buildinfo.json` to CSV format understood by link:util/tagrepos.sh[tagrepos.py].
+|Used when builds done and preparing for repositories to be tagged.
+
 |===
 
 == Composite Sites & Install Tests

--- a/util/buildinfo2tags.py
+++ b/util/buildinfo2tags.py
@@ -1,0 +1,44 @@
+import pprint, requests, re, os
+import sys
+from xml.dom import minidom
+from optparse import OptionParser
+import json
+
+pp = pprint.PrettyPrinter(indent=4)
+
+# moar output, set = 1
+debug=0
+
+usage = "Usage: cat buildinfo.json | %prog [-n NAME] \n\n\
+This script will convert a buildinfo.json to CSV list of projects, SHAs, and tags/branches."
+parser = OptionParser(usage)
+
+# required
+parser.add_option("-n", dest="name", help="symbolic name to use, jbosstools-4.3.0.Beta1")
+
+(options, args) = parser.parse_args()
+
+if (not options.name):
+    parser.error("Must to specify ALL commandline flags; use -h for help")
+
+j = json.load(sys.stdin) 
+if j:
+  
+  # upstream/*/revision/knownReferences[0]/url = git repo from which build happened, eg., "git://github.com/jbosstools/jbosstools-base.git"
+  # upstream/*/revision/knownReferences[0]/ref = branch from which build happened, eg., "jbosstools-4.3.0.Beta1x" or "master"
+  for entry in j['upstream']:
+      if debug : print "[DEBUG] " + entry
+      if type(j['upstream'][entry]) is dict :
+          if debug : print "[DEBUG] " + " >> " + j['upstream'][entry]["revision"]["HEAD"]
+          if debug : print "[DEBUG] " + " >> " + j['upstream'][entry]["revision"]["knownReferences"][0]["url"] # github project: "git://github.com/jbosstools/jbosstools-base.git"
+          if debug : print "[DEBUG] " + " >> " + j['upstream'][entry]["revision"]["knownReferences"][0]["ref"] # branch: "jbosstools-4.3.0.Beta1x" or "master"
+          m = re.search('.+/([^/]+)/([^/]+)\.git', j['upstream'][entry]["revision"]["knownReferences"][0]["url"]) 
+          if m:
+            org = m.group(1)
+            repo = m.group(2)
+            print(org + '/' + repo + ', ' + j['upstream'][entry]['revision']['HEAD'] + ', ' + options.name)
+      else :
+          print >> sys.stderr, "ERROR: Missing data for " + entry + ":" + j['upstream'][entry]
+
+else:
+  print "[ERROR] Could not load json"

--- a/util/tagrepos.py
+++ b/util/tagrepos.py
@@ -1,0 +1,44 @@
+from github import Github, GithubException
+import sys
+import csv
+
+if len(sys.argv) <> 3:
+    print "Please specify both username and github password."
+    print "Usage: cat tags.csv | tagrepos.py <username> <password>"
+    print "Takes CSV formatted stream as input following the format: "
+    print "github-reponame, sha1, tag"
+    print "Example:"
+    print "jbosstools/jbosstools-hibernate, a1f287bf825a891901b41739f6a4bbaafc70bcdd, jbosstools-4.2.1.Alpha23"
+    print
+    print "Useful when combined with buildinfo.json: "
+    print "cat buildinfo.json | python buildinfo2tags.py -n <tagname> | python tagrepos.py <taggeruser> <secret>" 
+    sys.exit(-1)
+
+repos = csv.reader(sys.stdin)
+          
+g = Github(sys.argv[1], sys.argv[2])
+
+for counter, row in enumerate(repos):
+    
+    reponame = row[0].strip()
+    sha1 = row[1].strip()
+    tag = 'refs/tags/' + row[2].strip()
+    results = "Failure!"
+    print "Tagging " + reponame + " with " + sha1 +  " as "  + tag
+    results = "Success!"
+    try:
+        repo = g.get_repo(reponame)
+        repo.create_git_ref(tag , sha1)
+        #ref = repo.get_git_ref('tags/' + row[2].strip())
+        #ref.delete()
+    except GithubException as ge:
+        if ge.status == 422 or ge.status == 400:
+            results = str(ge)
+        else:
+            raise
+
+        
+    print results
+
+    
+


### PR DESCRIPTION
Seperate python utilities to convert buildinfo.json to csv and then one for making the tags.

```
curl http://download.jboss.org/jbosstools/static/mars/development/updates/core/4.3.0.Beta1/buildinfo.json | python buildinfo_to_tags.py -n jbosstools-4.3.0.Beta1 | python tagrepos.py maxandersen secret
```