### PR TITLE
JBIDE-23962 fix mktemp calls to use -p...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.releng</groupId>
 	<artifactId>jbosstools-releng-publish</artifactId>
-	<version>4.4.3.Final</version>
+	<version>4.4.4.Final-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>JBoss Tools - Scripts for Release Engineering</name>

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -42,7 +42,7 @@ getRemoteFile ()
   # requires $wgetParams and $tmpdir to be defined (above)
   getRemoteFileReturn=""
   grfURL="$1"
-  output=`mktemp --tmpdir=${tmpdir} getRemoteFile.XXXXXX`
+  output=`mktemp -p ${tmpdir} getRemoteFile.XXXXXX`
   if [[ ! `wget ${wgetParams} ${grfURL} -O ${output} 2>&1 | egrep "ERROR 404"` ]]; then # file downloaded
     getRemoteFileReturn=${output}
   else

--- a/publish/rsync.sh
+++ b/publish/rsync.sh
@@ -143,7 +143,7 @@ getRemoteFile ()
 	getRemoteFileReturn=""
 	grfURL="$1"
 	mkdir -p ${tmpdir}
-	output=$(mktemp --tmpdir=${tmpdir} getRemoteFile.XXXXXX)
+	output=$(mktemp -p ${tmpdir} getRemoteFile.XXXXXX)
 	if [[ ! `wget ${wgetParams} ${grfURL} -O ${output} 2>&1 | egrep "ERROR 404"` ]]; then # file downloaded
 		getRemoteFileReturn=${output}
 	else

--- a/util/checkLatestPublishedSHA.sh
+++ b/util/checkLatestPublishedSHA.sh
@@ -47,7 +47,7 @@ getRemoteFile ()
   # requires $wgetParams and $tmpdir to be defined (above)
   getRemoteFileReturn=""
   grfURL="$1"
-  output=`mktemp --tmpdir=${tmpdir} getRemoteFile.XXXXXX`
+  output=`mktemp -p ${tmpdir} getRemoteFile.XXXXXX`
   if [[ ! `wget ${wgetParams} ${grfURL} -O ${output} 2>&1 | egrep "ERROR 404"` ]]; then # file downloaded
     getRemoteFileReturn=${output}
     # cat ${getRemoteFileReturn}


### PR DESCRIPTION
JBIDE-23962 fix mktemp calls to use -p instead of --tmpdir=; bump to 4.4.4.Final-SNAPSHOT

Signed-off-by: nickboldt <nboldt@redhat.com>