### PR TITLE
JBIDE-24666 add fusesource Jenkins as...

### DIFF
--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -749,14 +749,14 @@ find ${WORKSPACE} -maxdepth 2 -name "getRemoteFile*" -type f -exec rm -f {} \;
 
 if [[ ${JOB_NAME/.aggregate} != ${JOB_NAME} ]]; then
   # regenerate http://download.jboss.org/jbosstools/builds/nightly/*/*/composite*.xml files for up to 5 builds, cleaning anything older than 5 days old
-  if [[ ! -f jbosstools-cleanup.sh ]]; then 
+  # new approach using publish script from Nexus via jbosstools-build-ci-scripts_4.3.x
+  if [[ -f ${WORKSPACE}/sources/util/cleanup/jbosstools-cleanup.sh ]]; then
+    cd ${WORKSPACE}/sources/util/cleanup
+  elif [[ ! -f jbosstools-cleanup.sh ]]; then 
     wget -q --no-check-certificate -N https://raw.github.com/jbosstools/jbosstools-build-ci/master/util/cleanup/jbosstools-cleanup.sh
   fi
-  #pushd ${WORKSPACE}/sources/util/cleanup
   chmod +x jbosstools-cleanup.sh
   ./jbosstools-cleanup.sh --keep 5 --age-to-delete 5 --childFolderSuffix /all/repo/
-  rm -f jbosstools-cleanup.sh
-  #popd
 fi
 
 # to avoid looking for files that are still being synched/nfs-copied, wait a bit before trying to run tests (the next step usually)

--- a/util/getProjectRootPomParents.sh
+++ b/util/getProjectRootPomParents.sh
@@ -10,11 +10,11 @@
 
 usage ()
 {
-    echo "Usage:     $0 -b GITHUBBRANCH -pv PARENTVERSION [-skipupdate]"
+    echo "Usage:     $0 -b GITHUBBRANCH -pv PARENTVERSION [-skipupdate] -w1 [/path/to/jbosstools-projects/parent-folder] -w2 [/path/to/jbdevstudio-projects/parent-folder]"
     echo ""
-    echo "Example 1: $0 -b jbosstools-4.2.x -pv 4.2.1.CR1-SNAPSHOT"
+    echo "Example 1: $0 -b jbosstools-4.2.x -pv 4.2.3.CR1-SNAPSHOT -w1 /home/nboldt/42x -w2 /home/nboldt/42xx"
     echo ""
-    echo "Example 2: $0 -pv 4.2.1.Final-SNAPSHOT -skipupdate"
+    echo "Example 2: $0 -pv 4.3.0.Alpha2-SNAPSHOT -skipupdate -w1 /home/nboldt/tru -w2 /home/nboldt/truu"
     echo ""
     exit 1;
 }
@@ -24,16 +24,21 @@ if [[ $# -lt 1 ]]; then
 fi
 
 doGitUpdate=true
-parent=4.2.1.Final-SNAPSHOT # or 4.3.0.Alpha1-SNAPSHOT
+parent=4.2.3.Final-SNAPSHOT # or 4.3.0.Alpha1-SNAPSHOT
 branch=jbosstools-4.2.x # or master
-jbtstream=4.2.luna # or master
-jbdsstream=8.0.luna # or master 
+jbtstream=4.2.luna  # or 4.3.mars or master
+jbdsstream=8.0.luna # or 9.0.mars or master 
+
+WORKSPACE1=${HOME}/tru
+WORKSPACE2=${HOME}/truu
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     '-b') branch="$2"; shift 1;;
     '-pv') parent="$2"; shift 1;;
     '-skipupdate'|'-k') doGitUpdate=false; shift 0;;
+    '-w1') WORKSPACE1="$2"; shift 1;;
+    '-w2') WORKSPACE2="$2"; shift 1;;
   esac
   shift 1
 done
@@ -48,8 +53,8 @@ elif [[ ${branch/4.3/} != ${branch} ]]; then
 fi
 
 # TODO parameterize these?
-logfile=/tmp/log.txt
-errfile=/tmp/err.txt
+logfile=/tmp/getProjectRootPomParents.log.txt
+errfile=/tmp/getProjectRootPomParents.err.txt
 
 gitUpdate () {
   branch=$1
@@ -99,9 +104,9 @@ checkProjects () {
 echo "Found these root pom versions   [CORRECT]:" > ${logfile}; echo "" >> ${logfile}
 echo "Found these root pom versions [INCORRECT]:" > ${errfile}; echo "" >> ${errfile}
 
-checkProjects /home/nboldt/tru/jbosstools- "aerogear arquillian base birt browsersim central discovery forge freemarker hibernate javaee jst livereload openshift portlet server vpe webservices" pom.xml jbosstools- jbosstools/jbosstools- "${jbtstream}"
-checkProjects /home/nboldt/tru/jbosstools- "build-sites" aggregate/pom.xml jbosstools- jbosstools/jbosstools- "${jbtstream}"
-checkProjects  /home/nboldt/truu/jbdevstudio- "product" pom.xml devstudio. jbdevstudio/jbdevstudio- "${jbdsstream}"
+checkProjects ${WORKSPACE1}/jbosstools- "aerogear arquillian base birt browsersim central discovery forge freemarker hibernate javaee jst livereload openshift portlet server vpe webservices" pom.xml jbosstools- jbosstools/jbosstools- "${jbtstream}"
+checkProjects ${WORKSPACE1}/jbosstools- "build-sites" aggregate/pom.xml jbosstools- jbosstools/jbosstools- "${jbtstream}"
+checkProjects ${WORKSPACE2}/jbdevstudio- "product" pom.xml devstudio. jbdevstudio/jbdevstudio- "${jbdsstream}"
 
 cat $logfile
 echo ""

--- a/util/installFromCentral.sh
+++ b/util/installFromCentral.sh
@@ -27,6 +27,9 @@ fi
 #director.xml script is used with Eclipse's AntRunner to launch p2.director
 DIRECTORXML="http://download.jboss.org/jbosstools/updates/scripted-install/director.xml"
 
+# use Eclipse VM from JAVA_HOME if available
+if [[ -x ${JAVA_HOME}/bin/java ]]; then VM="-vm ${JAVA_HOME}/bin/java"; fi
+
 # read commandline args
 # NOTE: Jenkins matrix jobs require semi-colons here, but to pass to shell, must use quotes
 # On commandline, can use comma-separated pair instead so quotes aren't needed
@@ -37,6 +40,7 @@ while [[ "$#" -gt 0 ]]; do
     '-WORKSPACE') WORKSPACE="$2"; shift 1;;
     '-DIRECTORXML') DIRECTORXML="$2"; shift 1;;
     '-CLEAN') CLEAN="$2"; shift 1;;
+    '-VM') VM="-vm $2"
   esac
   shift 1
 done
@@ -68,7 +72,7 @@ SITES=${SITES%//}/
 # get a list of IUs to install from the JBT or JBDS update site (using p2.director -list)
 BASE_URL=${SITES%,*}
 # include source features too?
-${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
 list.feature.groups -Doutput=${WORKSPACE}/feature.groups.properties -DsourceSites=${BASE_URL}
 BASE_IUs=""
 if [[ -f ${WORKSPACE}/feature.groups.properties ]]; then 
@@ -79,7 +83,7 @@ fi
 date; du -sh ${ECLIPSE}
 
 # run scripted installation via p2.director
-${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
 -DsourceSites=${SITES} -Dinstall=${BASE_IUs}
 
 date; du -sh ${ECLIPSE}
@@ -126,7 +130,7 @@ if [[ $CENTRAL_URL != $INSTALL_PLAN ]]; then
 </xsl:stylesheet>
 XSLT
 
-  ${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml \
+  ${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} \
   transform -Dxslt=${WORKSPACE}/get-ius-and-siteUrls.xsl -Dinput=${WORKSPACE}/plugin.xml -Doutput=${WORKSPACE}/plugin.transformed.xml -q
 
   # parse the list of features from plugin.transformed.xml
@@ -143,7 +147,7 @@ XSLT
   date; du -sh ${ECLIPSE}
 
   # run scripted installation via p2.director
-  ${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+  ${ECLIPSE}/eclipse -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
   -DsourceSites=${SITES},${EXTRA_SITES} -Dinstall=${CENTRAL_IUs}
 
   date; du -sh ${ECLIPSE}

--- a/util/installFromCentral.sh
+++ b/util/installFromCentral.sh
@@ -40,7 +40,7 @@ while [[ "$#" -gt 0 ]]; do
     '-WORKSPACE') WORKSPACE="$2"; shift 1;;
     '-DIRECTORXML') DIRECTORXML="$2"; shift 1;;
     '-CLEAN') CLEAN="$2"; shift 1;;
-    '-VM') VM="-vm $2"
+    '-vm') VM="-vm $2"; shift 1;;
   esac
   shift 1
 done

--- a/util/installFromTarget.sh
+++ b/util/installFromTarget.sh
@@ -40,7 +40,7 @@ while [[ "$#" -gt 0 ]]; do
     '-WORKSPACE') WORKSPACE="$2"; shift 1;;
     '-DIRECTORXML') DIRECTORXML="$2"; shift 1;;
     '-CLEAN') CLEAN="$2"; shift 1;;
-    '-VM') VM="-vm $2"
+    '-vm') VM="-vm $2"; shift 1;;
   esac
   shift 1
 done

--- a/util/installFromTarget.sh
+++ b/util/installFromTarget.sh
@@ -27,6 +27,9 @@ fi
 #director.xml script is used with Eclipse's AntRunner to launch p2.director
 DIRECTORXML="http://download.jboss.org/jbosstools/updates/scripted-installation/director.xml"
 
+# use Eclipse VM from JAVA_HOME if available
+if [[ -x ${JAVA_HOME}/bin/java ]]; then VM="-vm ${JAVA_HOME}/bin/java"; fi
+
 # read commandline args
 # NOTE: Jenkins matrix jobs require semi-colons here, but to pass to shell, must use quotes
 # On commandline, can use comma-separated pair instead so quotes aren't needed
@@ -37,6 +40,7 @@ while [[ "$#" -gt 0 ]]; do
     '-WORKSPACE') WORKSPACE="$2"; shift 1;;
     '-DIRECTORXML') DIRECTORXML="$2"; shift 1;;
     '-CLEAN') CLEAN="$2"; shift 1;;
+    '-VM') VM="-vm $2"
   esac
   shift 1
 done
@@ -80,10 +84,10 @@ fi
 rm -fr ${WORKSPACE}/data; mkdir -p ${WORKSPACE}/data
 
 # collect feature.groups to install
-${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
 list.feature.groups -Doutput=${WORKSPACE}/feature.group.list.properties -DsourceSites=${INSTALL_PLAN} -Dexec=${ECLIPSEEXEC}
 # collect plugins to install (in case we have orphan plugins not inside feature.groups)
-${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
 list.plugins -Doutput=${WORKSPACE}/plugin.list.properties -DsourceSites=${INSTALL_PLAN} -Dexec=${ECLIPSEEXEC}
 BASE_IUs=""
 for f in feature.group.list.properties plugin.list.properties; do
@@ -101,7 +105,7 @@ BASE_IUs=${BASE_IUs:1}
 date; du -sh ${ECLIPSE}
 
 # run scripted installation via p2.director
-${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml -DtargetDir=${ECLIPSE} \
+${ECLIPSEEXEC} -consolelog -nosplash -data ${WORKSPACE}/data -application org.eclipse.ant.core.antRunner -f ${WORKSPACE}/director.xml ${VM} -DtargetDir=${ECLIPSE} \
 -DsourceSites=${INSTALL_PLAN} -Dinstall=${BASE_IUs} -Dexec=${ECLIPSEEXEC}
 
 date; du -sh ${ECLIPSE}

--- a/util/verifyTarget.sh
+++ b/util/verifyTarget.sh
@@ -113,7 +113,7 @@ NOW=`date +%F_%H-%M`
 
 if [[ ! $targetplatformutilsversion ]]; then
   # eg., 0.22.1-SNAPSHOT
-  targetplatformutilsversion=`cat ${BASEDIR}/pom.xml | grep util -B2 -A2 | grep version | sed -e "s#.\+<version>\(.\+\)</version>.*#\1#"`
+  targetplatformutilsversion=`cat ${BASEDIR}/pom.xml | egrep "jbossTychoPluginsVersion|util" -B2 -A2 | egrep "version|jbossTychoPluginsVersion" | sed -e "s#.\+<version>\(.\+\)</version>.*#\1#" -e "s#.\+<jbossTychoPluginsVersion>\(.\+\)</jbossTychoPluginsVersion>.*#\1#" | head -1`
 fi
 
 for PROJECT in $PROJECTS; do echo "Process $PROJECT ..."


### PR DESCRIPTION
JBIDE-24666 add fusesource Jenkins as fallback; add support for -jbtpath and -jbdspath vars; support 4th fallback check for buildinfo.json using projectMap[]; set oxygen/11 defaults for path vars

Signed-off-by: nickboldt <nboldt@redhat.com>